### PR TITLE
chore(dependencies): bump bouncycastle to 1.64

### DIFF
--- a/spinnaker-dependencies/spinnaker-dependencies.gradle
+++ b/spinnaker-dependencies/spinnaker-dependencies.gradle
@@ -7,13 +7,13 @@ javaPlatform {
 ext {
   versions = [
     aws              : "1.11.820",
-    bouncycastle     : "1.61",
+    bouncycastle     : "1.64", // 1.64 removes CVE-2019-17359
     brave            : "5.12.3",
     groovy           : "2.5.11", //this needs to keep in sync with the version from boot... if we could get rid of groovy-all we'd no longer need this
     jsch             : "0.1.54",
     jschAgentProxy   : "0.0.9",
     protobuf         : "3.9.1",
-    okhttp           : "2.7.5", // CVE-2016-2402
+    okhttp           : "2.7.5", // 2.7.5 removes CVE-2016-2402
     okhttp3          : "3.14.9",
     openapi          : "1.3.9", // this needs to be kept in sync with spring boot as it pulls in the spring-boot-dependencies BOM
     resilience4j     : "1.0.0",


### PR DESCRIPTION
bump bouncycastle to remove CVE that can cause outofmemory issues amongst other things